### PR TITLE
Download and Install FE Templates

### DIFF
--- a/ansible/roles/chd-app-config/files/deployment-scripts/frontend_deployment.yml
+++ b/ansible/roles/chd-app-config/files/deployment-scripts/frontend_deployment.yml
@@ -15,6 +15,25 @@
         - "htdocs"
       config_files:
         - "CHD"
+      template_files:
+        - "apps"
+        - "certdocorder"
+        - "certselect"
+        - "comp_details"
+        - "cosearch"
+        - "cosel"
+        - "crep_select"
+        - "docpackage"
+        - "docpackconf"
+        - "docpacklist"
+        - "fhist"
+        - "fullmort"
+        - "login"
+        - "mainmenu"
+        - "mortdetails"
+        - "mortgages"
+        - "pers_apps"
+        - "viewdoc"
     roles:
       - { role: /root/roles/nfs_mounts }
       - name: ch_collections.base.cloudwatch_agent_config
@@ -82,6 +101,22 @@
           group: chlservices
           mode: 0755
         loop: "{{ config_files }}"
+
+      - name: Download template files from S3
+        aws_s3:
+          bucket: "{{ s3_bucket_configs }}"
+          object: "chl-{{ application_config_name }}-configs/{{ heritage_environment }}/templates/{{ item }}.tmpl"
+          dest: "{{ home_dir }}/htdocs/chd3/templates/en/stdchd/{{ item }}.tmpl"
+          mode: get
+        loop: "{{ template_files }}"
+
+      - name: Change template files owner and permissions
+        ansible.builtin.file:
+          path: "{{ home_dir }}/htdocs/chd3/templates/en/stdchd/{{ item }}.tmpl"
+          owner: "{{ home_dir | basename }}"
+          group: chlservices
+          mode: 0755
+        loop: "{{ template_files }}"
 
       - name: Cleanup install files
         file:


### PR DESCRIPTION
Added tasks to `frontend_deployment.yml` to download templates files from S3 and install them with appropriate ownership and permissions.